### PR TITLE
fix: fixed building on macOS

### DIFF
--- a/qmc2.pro
+++ b/qmc2.pro
@@ -335,6 +335,7 @@ contains(DEFINES, QMC2_BUNDLED_MINIZIP) {
 
 contains(DEFINES, QMC2_BUNDLED_ZLIB) {
 	INCLUDEPATH += src/zlib
+	QMAKE_CFLAGS += -DHAVE_UNISTD_H
 	SOURCES += src/zlib/adler32.c \
 		src/zlib/compress.c \
 		src/zlib/crc32.c \

--- a/qmc2.pro
+++ b/qmc2.pro
@@ -360,6 +360,7 @@ macx {
 	greaterThan(SDL, 1) {
 		LIBS += -framework SDL2 -framework Cocoa -F/Library/Frameworks
 		INCLUDEPATH += /Library/Frameworks/SDL2.framework/Headers
+		QMAKE_CXXFLAGS += -framework SDL2 -F/Library/Frameworks
 	} else {
 		OBJECTIVE_SOURCES += src/SDLMain_tmpl.m
 		HEADERS += src/SDLMain_tmpl.h

--- a/qmc2.pro
+++ b/qmc2.pro
@@ -335,7 +335,9 @@ contains(DEFINES, QMC2_BUNDLED_MINIZIP) {
 
 contains(DEFINES, QMC2_BUNDLED_ZLIB) {
 	INCLUDEPATH += src/zlib
-	QMAKE_CFLAGS += -DHAVE_UNISTD_H
+	!win32 {
+		QMAKE_CFLAGS += -DHAVE_UNISTD_H
+	}
 	SOURCES += src/zlib/adler32.c \
 		src/zlib/compress.c \
 		src/zlib/crc32.c \


### PR DESCRIPTION
* Make sure headers can be found with SDL2-2.24.2 and newer
* Fix implicit function declaration warning causing a build failure on macOS 14