### PR TITLE
imp: Updated SDL2 used by Windows and macOS CI to 2.30.1

### DIFF
--- a/.github/workflows/ci-macos.yml
+++ b/.github/workflows/ci-macos.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  SDL_VERSION: 2.30.1
+
 jobs:
   build:
 
@@ -23,8 +26,8 @@ jobs:
       run: |
         brew update
         brew install qt@5
-        wget https://github.com/libsdl-org/SDL/releases/download/release-2.30.0/SDL2-2.30.0.dmg
-        sudo hdiutil attach SDL2-2.30.0.dmg
+        wget https://github.com/libsdl-org/SDL/releases/download/release-$SDL_VERSION/SDL2-$SDL_VERSION.dmg
+        sudo hdiutil attach SDL2-$SDL_VERSION.dmg
         sudo cp -R /Volumes/SDL2/SDL2.framework /Library/Frameworks
         sudo hdiutil detach /Volumes/SDL2
     - name: Build

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -4,6 +4,9 @@ on:
   push:
   pull_request:
 
+env:
+  SDL_VERSION: 2.30.1
+
 jobs:
   build:
 
@@ -23,7 +26,7 @@ jobs:
           cache: true
       - name: Download SDL
         run: |
-          Invoke-WebRequest "https://github.com/libsdl-org/SDL/releases/download/release-2.30.0/SDL2-devel-2.30.0-VC.zip" -OutFile ${{ runner.workspace }}\SDL2.zip
+          Invoke-WebRequest "https://github.com/libsdl-org/SDL/releases/download/release-$env:SDL_VERSION/SDL2-devel-$env:SDL_VERSION-VC.zip" -OutFile ${{ runner.workspace }}\SDL2.zip
           Expand-Archive ${{ runner.workspace }}\SDL2.zip -DestinationPath ${{ runner.workspace }}
       - uses: ilammy/msvc-dev-cmd@v1
       - uses: msys2/setup-msys2@v2
@@ -38,8 +41,8 @@ jobs:
           FORCE_MINGW: 0
           ARCH: Windows
           SDL: 2
-          SDL_LIBS: 'LIBS+="../SDL2-2.30.0/lib/x64/SDL2.lib ../SDL2-2.30.0/lib/x64/SDL2main.lib"'
-          SDL_INCLUDEPATH: 'INCLUDEPATH+=../SDL2-2.30.0/include'
+          SDL_LIBS: 'LIBS+="../SDL2-${SDL_VERSION}/lib/x64/SDL2.lib ../SDL2-${SDL_VERSION}/lib/x64/SDL2main.lib"'
+          SDL_INCLUDEPATH: 'INCLUDEPATH+=../SDL2-${SDL_VERSION}/include'
         shell: msys2 {0}
         run: make -j4 configure
       - name: Build
@@ -47,7 +50,7 @@ jobs:
       - name: Deploy
         run: |
           windeployqt release\qmc2-mame.exe
-          Copy-Item ${{ runner.workspace }}\SDL2-2.30.0\lib\x64\SDL2.dll  release
+          Copy-Item ${{ runner.workspace }}\SDL2-$env:SDL_VERSION\lib\x64\SDL2.dll  release
       - uses: actions/upload-artifact@v4
         with:
           name: qmc2-windows-2019-${{ github.sha }}


### PR DESCRIPTION
macos-latest build fails due to https://github.com/actions/setup-python/issues/577, not sure if it is something that needs to be worked around. An alternative approach would be to attempt building a universal binary on macos-14.